### PR TITLE
Allow spaces in +CMGL response in PDU mode

### DIFF
--- a/gsmmodem/modem.py
+++ b/gsmmodem/modem.py
@@ -810,7 +810,7 @@ class GsmModem(SerialComms):
                 messages.append(ReceivedSms(self, Sms.TEXT_MODE_STATUS_MAP[msgStatus], number, parseTextModeTimeStr(msgTime), msgText))
                 delMessages.add(int(msgIndex))
         else:
-            cmglRegex = re.compile(r'^\+CMGL:\s*(\d+),(\d+),.*$')
+            cmglRegex = re.compile(r'^\+CMGL:\s*(\d+),\s*(\d+),.*$')
             readPdu = False
             result = self.write('AT+CMGL={0}'.format(status))
             for line in result:


### PR DESCRIPTION
The D-Link DWM-156 has +CGML responses of the following format:
+CMGL: 1, 0,[...]

Previous regex did not allow spaces between the index and the message
status.
