### PR TITLE
Arduino, sim900 fixes

### DIFF
--- a/tools/identify-modem.py
+++ b/tools/identify-modem.py
@@ -21,7 +21,8 @@ def parseArgs():
     parser.add_argument('port', metavar='PORT', help='port to which the GSM modem is connected; a number or a device name.')
     parser.add_argument('-b', '--baud', metavar='BAUDRATE', default=115200, help='set baud rate')
     parser.add_argument('-p', '--pin', metavar='PIN', default=None, help='SIM card PIN')
-    parser.add_argument('-d', '--debug',  action='store_true', help='dump modem debug information (for python-gsmmodem development)')    
+    parser.add_argument('-d', '--debug',  action='store_true', help='dump modem debug information (for python-gsmmodem development)')
+    parser.add_argument('-w', '--wait', type=int, default=0, help='Wait for modem to start, in seconds')
     return parser.parse_args()
 
 def parseArgsPy26():
@@ -32,6 +33,7 @@ def parseArgsPy26():
     parser.add_option('-b', '--baud', metavar='BAUDRATE', default=115200, help='set baud rate')
     parser.add_option('-p', '--pin', metavar='PIN', default=None, help='SIM card PIN')
     parser.add_option('-d', '--debug',  action='store_true', help='dump modem debug information (for python-gsmmodem development)')
+    parser.add_option('-w', '--wait', type=int, default=0, help='Wait for modem to start, in seconds')
     options, args = parser.parse_args()
     if len(args) != 1:    
         parser.error('Incorrect number of arguments - please specify a PORT to connect to, e.g. {0} /dev/ttyUSB0'.format(sys.argv[0]))
@@ -46,7 +48,7 @@ def main():
     
     print('Connecting to GSM modem on {0}...'.format(args.port))
     try:
-        modem.connect(args.pin)
+        modem.connect(args.pin, waitingForModemToStartInSeconds=args.wait)
     except PinRequiredError:
         sys.stderr.write('Error: SIM card PIN required. Please specify a PIN with the -p argument.\n')
         sys.exit(1)

--- a/tools/sendsms.py
+++ b/tools/sendsms.py
@@ -19,8 +19,10 @@ def parseArgs():
     parser.add_argument('-i', '--port', metavar='PORT', help='port to which the GSM modem is connected; a number or a device name.')
     parser.add_argument('-b', '--baud', metavar='BAUDRATE', default=115200, help='set baud rate')
     parser.add_argument('-p', '--pin', metavar='PIN', default=None, help='SIM card PIN')
-    parser.add_argument('-d', '--deliver',  action='store_true', help='wait for SMS delivery report')
-    parser.add_argument('destination', metavar='DESTINATION', help='destination mobile number')    
+    parser.add_argument('-d', '--deliver', action='store_true', help='wait for SMS delivery report')
+    parser.add_argument('-w', '--wait', type=int, default=0, help='Wait for modem to start, in seconds')
+    parser.add_argument('--CNMI', default='', help='Set the CNMI of the modem, used for message notifications')
+    parser.add_argument('destination', metavar='DESTINATION', help='destination mobile number')
     return parser.parse_args()
     
 def parseArgsPy26():
@@ -30,7 +32,9 @@ def parseArgsPy26():
     parser.add_option('-i', '--port', metavar='PORT', help='port to which the GSM modem is connected; a number or a device name.')
     parser.add_option('-b', '--baud', metavar='BAUDRATE', default=115200, help='set baud rate')
     parser.add_option('-p', '--pin', metavar='PIN', default=None, help='SIM card PIN')
-    parser.add_option('-d', '--deliver',  action='store_true', help='wait for SMS delivery report')
+    parser.add_option('-d', '--deliver', action='store_true', help='wait for SMS delivery report')
+    parser.add_option('-w', '--wait', type=int, default=0, help='Wait for modem to start, in seconds')
+    parser.add_option('--CNMI', default='', help='Set the CNMI of the modem, used for message notifications')
     parser.add_positional_argument(Option('--destination', metavar='DESTINATION', help='destination mobile number'))    
     options, args = parser.parse_args()
     if len(args) != 1:    
@@ -44,13 +48,13 @@ def main():
     if args.port == None:
         sys.stderr.write('Error: No port specified. Please specify the port to which the GSM modem is connected using the -i argument.\n')
         sys.exit(1)
-    modem = GsmModem(args.port, args.baud)    
+    modem = GsmModem(args.port, args.baud, AT_CNMI=args.CNMI)
     # Uncomment the following line to see what the modem is doing:
     #logging.basicConfig(format='%(levelname)s: %(message)s', level=logging.DEBUG)
     
     print('Connecting to GSM modem on {0}...'.format(args.port))
     try:
-        modem.connect(args.pin)
+        modem.connect(args.pin, waitingForModemToStartInSeconds=args.wait)
     except PinRequiredError:
         sys.stderr.write('Error: SIM card PIN required. Please specify a PIN with the -p argument.\n')
         sys.exit(1)


### PR DESCRIPTION
So i´m using a sim900 modem with Arduino as a serial interface.
While trying to connect to it, i would always get a timeOutException,
turns out that Arduino reboots it-self every time a new serial connection 
starts so, when the first AT command get send, Arduino isn’t on yet, so it 
never reaches the sim900 modem, modem doesn’t respond, timeOutException.
waiting for 2-3 sec does the trick.

Also i needed a way to set a custom CNMI, since the default one doesn’t work
with the sim900 modem.
###### 

added "waittingForModemToStartInSeconds" argument to GsmModem.conect(), added AT_CNMI property to GsmModem.

The waittingForModemToStartInSeconds arg allows to wait after the
serial connection has started, and before sending the AT commands.

The AT_CNMI proprety of the GsmModem class allow to specify the CNMI
parameter of the gsm modem, this helps to set up the incoming sms
notifications.
