### PR TITLE
Update serial_comms.py

### DIFF
--- a/gsmmodem/serial_comms.py
+++ b/gsmmodem/serial_comms.py
@@ -90,7 +90,7 @@ class SerialComms(object):
             readTermLen = len(readTermSeq)
             rxBuffer = []
             while self.alive:
-                data = self.serial.read(1)
+                data = self.serial.read(1).decode() #Python 3.x compatibility
                 if data != '': # check for timeout
                     #print >> sys.stderr, ' RX:', data,'({0})'.format(ord(data))
                     rxBuffer.append(data)
@@ -124,7 +124,7 @@ class SerialComms(object):
                     self._expectResponseTermSeq = list(expectedResponseTermSeq) 
                 self._response = []
                 self._responseEvent = threading.Event()                
-                self.serial.write(data)
+                self.serial.write(data.encode()) #Python 3.x compatibility
                 if self._responseEvent.wait(timeout):
                     self._responseEvent = None
                     self._expectResponseTermSeq = False


### PR DESCRIPTION
Seems like `self.serial.read(1)` in `serial_comms.py` returns bytes in Python 3.x. 
But code expects strings and compares returned value with strings like `RX_EOL_SEQ = '\r\n'` or ''. The comparison result will always be `False`.
In this case `SerialComms` will never `_handleLineRead` and `TimeoutException` will be raised.
