### PR TITLE
Accept error messages like '+CME ERROR:58' without a space after ':'

### DIFF
--- a/gsmmodem/serial_comms.py
+++ b/gsmmodem/serial_comms.py
@@ -18,7 +18,7 @@ class SerialComms(object):
     # End-of-line read terminator
     RX_EOL_SEQ = '\r\n'
     # End-of-response terminator
-    RESPONSE_TERM = re.compile(r'^OK|ERROR|(\+CM[ES] ERROR: \d+)|(COMMAND NOT SUPPORT)$')
+    RESPONSE_TERM = re.compile(r'^OK|ERROR|(\+CM[ES] ERROR: ?\d+)|(COMMAND NOT SUPPORT)$')
     # Default timeout for serial port reads (in seconds)
     timeout = 1
         

--- a/test/test_serial_comms.py
+++ b/test/test_serial_comms.py
@@ -182,6 +182,8 @@ class TestWrite(unittest.TestCase):
         """ Tests basic writing operations """
         tests = ((['OK\r\n'], ['OK']),
                  (['ERROR\r\n'], ['ERROR']),
+                 (['+CMS ERROR: 58\r\n'], ['+CMS ERROR: 58']),
+                 (['+CME ERROR:58\r\n'], ['+CME ERROR:58']),
                  (['first line\r\n', 'second line\r\n', 'OK\r\n'], ['first line', 'second line', 'OK']),
                  # Some Huawei modems issue this response instead of ERROR for unknown commands; ensure we detect it correctly
                  (['COMMAND NOT SUPPORT\r\n'], ['COMMAND NOT SUPPORT']))


### PR DESCRIPTION
My A6 GSM modem returns such error codes. This caused the library to
hang, waiting for a response indefinitely.  After this change modem
initialization succeeds and it's possible to send SMS messages etc.

It could be also the cause of #24, the symptoms are very similar.