### PR TITLE
docs: Fix a few typos

### DIFF
--- a/gsmmodem/modem.py
+++ b/gsmmodem/modem.py
@@ -1089,7 +1089,7 @@ class GsmModem(SerialComms):
         """ Deletes all SMS messages that have the specified read status.
         
         The messages are read from the memory set by the "memory" parameter.
-        The value of the "delFlag" paramater is the same as the "DelFlag" parameter of the +CMGD command:
+        The value of the "delFlag" parameter is the same as the "DelFlag" parameter of the +CMGD command:
         1: Delete All READ messages
         2: Delete All READ and SENT messages
         3: Delete All READ, SENT and UNSENT messages
@@ -1243,7 +1243,7 @@ class Call(object):
         
         Note: this is highly device-dependent, and might not work
         
-        :param digits: A str containining one or more DTMF tones to play, e.g. "3" or "\*123#"
+        :param digits: A str containing one or more DTMF tones to play, e.g. "3" or "\*123#"
 
         :raise CommandError: if the command failed/is not supported        
         :raise InvalidStateException: if the call has not been answered, or is ended while the command is still executing

--- a/gsmmodem/pdu.py
+++ b/gsmmodem/pdu.py
@@ -357,7 +357,7 @@ def encodeSmsSubmitPdu(number, text, reference=0, validity=None, smsc=None, requ
 def decodeSmsPdu(pdu):
     """ Decodes SMS pdu data and returns a tuple in format (number, text)
     
-    :param pdu: PDU data as a hex string, or a bytearray containing PDU octects
+    :param pdu: PDU data as a hex string, or a bytearray containing PDU octets
     :type pdu: str or bytearray
     
     :raise EncodingError: If the specified PDU data cannot be decoded
@@ -527,7 +527,7 @@ def _encodeTimestamp(timestamp):
 
 def _decodeDataCoding(octet):
     if octet & 0xC0 == 0:
-        #compressed = octect & 0x20
+        #compressed = octet & 0x20
         alphabet = (octet & 0x0C) >> 2
         return alphabet # 0x00 == GSM-7, 0x01 == 8-bit data, 0x02 == UCS2
     # We ignore other coding groups

--- a/test/test_gsmterm.py
+++ b/test/test_gsmterm.py
@@ -53,7 +53,7 @@ class TestTrie(unittest.TestCase):
         self.assertRaises(KeyError, self.trie.__delitem__, 'unknown key')
         # Delete zero-length unknown key
         self.assertRaises(KeyError, self.trie.__delitem__, '')
-        # Delete zero-lenght known key
+        # Delete zero-length known key
         self.trie[''] = '123'
         self.assertEqual(len(self.trie), 1)
         del self.trie['']

--- a/test/test_modem.py
+++ b/test/test_modem.py
@@ -514,7 +514,7 @@ class TestEdgeCases(unittest.TestCase):
                 gsmmodem.serial_comms.serial = mockSerial        
                 modem = gsmmodem.modem.GsmModem('-- PORT IGNORED DURING TESTS --')
                 modem.connect()
-                # Make sure SMSC number was prevented from being deleted (some modems do this when setting text-mode paramters AT+CSMP)
+                # Make sure SMSC number was prevented from being deleted (some modems do this when setting text-mode parameters AT+CSMP)
                 self.assertEqual(test, modem.smsc, 'SMSC number was changed/deleted during connect()')
                 modem.close()
         FAKE_MODEM = None
@@ -1157,7 +1157,7 @@ class TestIncomingCall(unittest.TestCase):
     
     def test_incomingCallCrcChangedExternally(self):
         """ Tests handling incoming call notifications when the +CRC setting \
-        was modfied by some external program (issue #18) """
+        was modified by some external program (issue #18) """
         
         callReceived = [False]
         def callbackFunc(call):
@@ -1353,8 +1353,8 @@ class TestSms(unittest.TestCase):
         self.modem.close()
     
     def test_sendSmsResponseMixedWithUnsolictedMessages(self):
-        """ Tests sending a SMS messages (PDU mode), but with unsolicted messages mixed into the modem responses
-        - the only difference here is that the modem's responseSequence contains unsolicted messages
+        """ Tests sending a SMS messages (PDU mode), but with unsolicited messages mixed into the modem responses
+        - the only difference here is that the modem's responseSequence contains unsolicited messages
         taken from github issue #11
         """
         self.initModem(None)
@@ -1369,14 +1369,14 @@ class TestSms(unittest.TestCase):
             def writeCallbackFunc(data):
                 def writeCallbackFunc2(data):
                     self.assertEqual('{0}{1}'.format(pduHex, chr(26)), data, 'Invalid data written to modem; expected "{0}", got: "{1}"'.format('{0}{1}'.format(pduHex, chr(26)), data))
-                    # Note thee +ZDONR and +ZPASR unsolicted messages in the "response"
+                    # Note thee +ZDONR and +ZPASR unsolicited messages in the "response"
                     self.modem.serial.responseSequence =  ['+ZDONR: "METEOR",272,3,"CS_ONLY","ROAM_OFF"\r\n', '+ZPASR: "UMTS"\r\n', '+ZDONR: "METEOR",272,3,"CS_PS","ROAM_OFF"\r\n', '+ZPASR: "UMTS"\r\n', '+CMGS: {0}\r\n'.format(ref), 'OK\r\n']
                 self.assertEqual('AT+CMGS={0}\r'.format(calcPdu.tpduLength), data, 'Invalid data written to modem; expected "{0}", got: "{1}"'.format('AT+CMGS={0}'.format(calcPdu.tpduLength), data))
                 self.modem.serial.writeCallbackFunc = writeCallbackFunc2
             self.modem.serial.writeCallbackFunc = writeCallbackFunc
             self.modem.serial.flushResponseSequence = True
             
-            # Note thee +ZDONR and +ZPASR unsolicted messages in the "response"
+            # Note thee +ZDONR and +ZPASR unsolicited messages in the "response"
             self.modem.serial.responseSequence = ['+ZDONR: "METEOR",272,3,"CS_ONLY","ROAM_OFF"\r\n', '+ZPASR: "UMTS"\r\n', '> \r\n']
                         
             sms = self.modem.sendSms(number, message)


### PR DESCRIPTION
There are small typos in:
- gsmmodem/modem.py
- gsmmodem/pdu.py
- test/test_gsmterm.py
- test/test_modem.py

Fixes:
- Should read `unsolicited` rather than `unsolicted`.
- Should read `parameters` rather than `paramters`.
- Should read `parameter` rather than `paramater`.
- Should read `octets` rather than `octects`.
- Should read `octet` rather than `octect`.
- Should read `modified` rather than `modfied`.
- Should read `length` rather than `lenght`.
- Should read `containing` rather than `containining`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md