### PR TITLE
Add error catch to the _handleSmsStatusReport function, fixes #56

### DIFF
--- a/gsmmodem/modem.py
+++ b/gsmmodem/modem.py
@@ -1006,8 +1006,15 @@ class GsmModem(SerialComms):
         if cdsiMatch:
             msgMemory = cdsiMatch.group(1)
             msgIndex = cdsiMatch.group(2)
-            report = self.readStoredSms(msgIndex, msgMemory)
-            self.deleteStoredSms(msgIndex)
+            try:
+                report = self.readStoredSms(msgIndex, msgMemory)
+            except:
+                #This handles an intermittent issue where the modem responds with a non-response like object.
+                self.log.error('Error during processing of SMS Status Report')
+            finally:
+                #It's probably best to delete the stored response since we couldn't process it effectively.
+                self.deleteStoredSms(msgIndex)
+                return
             # Update sent SMS status if possible            
             if report.reference in self.sentSms:                
                 self.sentSms[report.reference].report = report


### PR DESCRIPTION
The message handler sometimes errors for a reason I'm not familiar with:
![image](https://github.com/user-attachments/assets/854f7ec6-6324-49e5-89d8-f04ccb335744)

I add a try block to the line to let it fail more gracefully. I've implemented this on my instance and it has resolved the issue and allowed for reliable operation of the repository. 

Tested on BananaPiR3-mini with Quecetel EC25G on T-Mobile. 

This is my first open-source PR, I am open to suggestions and corrections. 